### PR TITLE
open text editor when log source file is clicked

### DIFF
--- a/src/components/LogEntryMessage.tsx
+++ b/src/components/LogEntryMessage.tsx
@@ -1,0 +1,75 @@
+// Copyright 2019 Stratumn
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import graphql from "babel-plugin-relay/macro";
+import React, { Fragment } from "react";
+
+import { createFragmentContainer } from "react-relay";
+
+import { LogEntryMessage_item } from "./__generated__/LogEntryMessage_item.graphql";
+
+export interface IProps {
+  item: LogEntryMessage_item;
+  onClickSourceFile: (values: IProps) => any;
+}
+
+export function LogEntryMessage(props: IProps) {
+  const {
+    item: {
+      message,
+      sourceFile,
+      sourceFileBegin,
+      sourceFileEnd,
+    },
+    onClickSourceFile,
+  } = props;
+
+  if (!sourceFile) {
+    return (
+      <Fragment>
+        {message}
+      </Fragment>
+    );
+  }
+
+  const preSource = message.substring(0, sourceFileBegin!);
+  const source = message.substring(sourceFileBegin!, sourceFileEnd!);
+  const postSource = message.substring(sourceFileEnd!);
+  const handleClickSource = (event: React.MouseEvent) => {
+    event.preventDefault();
+    onClickSourceFile({ ...props });
+  };
+
+  return (
+    <Fragment>
+      {preSource}
+      <a
+        href={`file:///${sourceFile}`}
+        onClick={handleClickSource}
+      >
+        {source}
+      </a>
+      {postSource}
+    </Fragment>
+  );
+}
+
+export default createFragmentContainer(LogEntryMessage, graphql`
+  fragment LogEntryMessage_item on LogEntry {
+    message
+    sourceFile
+    sourceFileBegin
+    sourceFileEnd
+  }`,
+);

--- a/src/components/LogEntryTable.tsx
+++ b/src/components/LogEntryTable.tsx
@@ -22,13 +22,15 @@ import {
 
 import { LogEntryTable_items } from "./__generated__/LogEntryTable_items.graphql";
 
+import { IProps as ILogEntryMessageProps } from "./LogEntryMessage";
 import LogEntryTableRow from "./LogEntryTableRow";
 
 export interface IProps {
   items: LogEntryTable_items;
+  onClickSourceFile: (values: ILogEntryMessageProps) => any;
 }
 
-export function LogEntryTable({ items }: IProps) {
+export function LogEntryTable({ items, onClickSourceFile }: IProps) {
   if (items.length < 1) {
     return <Segment>There are no log entries at this time.</Segment>;
   }
@@ -37,6 +39,7 @@ export function LogEntryTable({ items }: IProps) {
     <LogEntryTableRow
       key={item.id}
       item={item}
+      onClickSourceFile={onClickSourceFile}
     />
   ));
 

--- a/src/components/LogEntryTableRow.tsx
+++ b/src/components/LogEntryTableRow.tsx
@@ -16,7 +16,6 @@ import graphql from "babel-plugin-relay/macro";
 import { Link } from "found";
 import React, { Fragment } from "react";
 import {
-  Accordion,
   Responsive,
   Table,
  } from "semantic-ui-react";
@@ -26,21 +25,26 @@ import { createFragmentContainer } from "react-relay";
 
 import { LogEntryTableRow_item } from "./__generated__/LogEntryTableRow_item.graphql";
 
+import LogEntryMessage, { IProps as ILogEntryMessageProps } from "./LogEntryMessage";
+
 import "./LogEntryTableRow.css";
 
 const dateFormat = "L LTS";
 
 export interface IProps {
   item: LogEntryTableRow_item;
+  onClickSourceFile: (values: ILogEntryMessageProps) => any;
 }
 
-export function LogEntryTableRow({ item: { createdAt, level, owner, message } }: IProps) {
-  const panels = [{
-    content: JSON.stringify(owner, null, 2),
-    key: "details",
-    title: message,
-  }];
-
+export function LogEntryTableRow({
+  item,
+  item: {
+    createdAt,
+    level,
+    owner,
+  },
+  onClickSourceFile,
+}: IProps) {
   let ownerEl: JSX.Element | null = null;
 
   if (owner) {
@@ -86,7 +90,10 @@ export function LogEntryTableRow({ item: { createdAt, level, owner, message } }:
         {ownerEl}
       </Table.Cell>
       <Table.Cell>
-        <Accordion panels={panels} />
+        <LogEntryMessage
+          item={item}
+          onClickSourceFile={onClickSourceFile}
+        />
       </Table.Cell>
     </Table.Row>
   );
@@ -96,33 +103,14 @@ export default createFragmentContainer(LogEntryTableRow, graphql`
   fragment LogEntryTableRow_item on LogEntry {
     createdAt
     level
-    message
+    ...LogEntryMessage_item
     owner {
       __typename
       id
       ... on Project {
         slug
         workspace {
-          id
           slug
-        }
-      }
-      ... on Job {
-        name
-        owner {
-          __typename
-          id
-        }
-      }
-      ... on Process {
-        command
-        project {
-          id
-          slug
-          workspace {
-            id
-            slug
-          }
         }
       }
     }

--- a/src/containers/LogEntryListPage.tsx
+++ b/src/containers/LogEntryListPage.tsx
@@ -23,8 +23,10 @@ import { LogEntryListPage_system } from "./__generated__/LogEntryListPage_system
 import { LogEntryListPage_viewer } from "./__generated__/LogEntryListPage_viewer.graphql";
 
 import LogEntryFilter, { IProps as ILogEntryFilterProps } from "../components/LogEntryFilter";
+import { IProps as ILogEntryMessageProps } from "../components/LogEntryMessage";
 import LogEntryTable from "../components/LogEntryTable";
 
+import { commit as openEditor } from "../mutations/openEditor";
 import { subscribe } from "../subscriptions/logEntryAdded";
 
 import "./LogEntryListPage.css";
@@ -69,7 +71,10 @@ export class LogEntryListPage extends Component<IProps> {
           ownerId={ownerId}
           onChange={this.handleFiltersChange}
         />
-        <LogEntryTable items={items} />
+        <LogEntryTable
+          items={items}
+          onClickSourceFile={this.handleClickSourceFile}
+        />
       </Container>
     );
   }
@@ -154,6 +159,10 @@ export class LogEntryListPage extends Component<IProps> {
     }
 
     this.props.router.replace(`/logs/${level.join(",")};${ownerId || ""}`);
+  }
+
+  private handleClickSourceFile = ({ item: { sourceFile } }: ILogEntryMessageProps) => {
+    openEditor(this.props.relay.environment, sourceFile!);
   }
 
   private handleScroll = () => {

--- a/src/mutations/openEditor.tsx
+++ b/src/mutations/openEditor.tsx
@@ -1,0 +1,32 @@
+// Copyright 2019 Stratumn
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import graphql from "babel-plugin-relay/macro";
+import { commitMutation } from "react-relay";
+import { Environment } from "relay-runtime";
+
+const mutation = graphql`
+  mutation openEditorMutation($filename: String!) {
+    openEditor(filename: $filename) {
+      ok
+    }
+  }
+`;
+
+export function commit(environment: Environment, filename: string) {
+  commitMutation(environment, {
+    mutation,
+    variables: { filename },
+  });
+}


### PR DESCRIPTION

This change allows a user to set a text editor command using the flag
--open-editor-command that will be used to open a text editor when a
path to a source file is clicked in a log message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/groundcontrol-ui/1)
<!-- Reviewable:end -->
